### PR TITLE
Promisify optionParser.parse() for async actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,34 @@
+{
+  "env": {
+    "browser": false,
+    "commonjs": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 12
+  },
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "no-invalid-this": [
+      "error"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *.swp
+.DS_Store
+.project
+node_modules
+*.sublime-workspace
+*.sublime-project
+.vstags
+*.code-workspace

--- a/bin/test-executor.js
+++ b/bin/test-executor.js
@@ -5,43 +5,43 @@
 var display, OptionParser, parser, unparsed;
 
 function pad(number) {
-    var p;
+  var p;
 
-    p = [];
-    p.length = number + 1;
+  p = [];
+  p.length = number + 1;
 
-    return p.join(' ');
+  return p.join(' ');
 }
 
 function displayArray(what, spacesIndent) {
-    what.forEach(function (item) {
-        display(pad(spacesIndent) + '-', item, spacesIndent);
-    });
+  what.forEach(function (item) {
+    display(pad(spacesIndent) + '-', item, spacesIndent);
+  });
 }
 
 function displayObject(what, spacesIndent) {
-    spacesIndent = +spacesIndent || 0;
-    Object.keys(what).sort().forEach(function (key) {
-        display(pad(spacesIndent) + key + ':', what[key], spacesIndent);
-    });
+  spacesIndent = +spacesIndent || 0;
+  Object.keys(what).sort().forEach(function (key) {
+    display(pad(spacesIndent) + key + ':', what[key], spacesIndent);
+  });
 }
 
 display = function (label, value, previousIndent) {
-    var nextIndent;
+  var nextIndent;
 
-    nextIndent = previousIndent + 4;
+  nextIndent = previousIndent + 4;
 
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        console.log(label + ' ' + value);
-    } else if (Array.isArray(value)) {
-        console.log(label);
-        displayArray(value, nextIndent);
-    } else if (typeof value === 'object') {
-        console.log(label);
-        displayObject(value, nextIndent);
-    } else {
-        console.log(typeof value);
-    }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    console.log(label + ' ' + value);
+  } else if (Array.isArray(value)) {
+    console.log(label);
+    displayArray(value, nextIndent);
+  } else if (typeof value === 'object') {
+    console.log(label);
+    displayObject(value, nextIndent);
+  } else {
+    console.log(typeof value);
+  }
 };
 
 OptionParser = require('..');
@@ -49,68 +49,68 @@ parser = new OptionParser();
 parser.programName('test-executor');
 
 parser.addOption('b', 'boolean', 'Boolean flag')
-    .action(function () {
-        console.log('Boolean');
-    });
+  .action(function () {
+    console.log('Boolean');
+  });
 
 parser.addOption([
-    'h',
-    '?'
+  'h',
+  '?'
 ], 'help', 'This help message')
-    .action(parser.helpAction());
+  .action(parser.helpAction());
 
 parser.addOption('z', 'hidden')
-    .action(function () {
-        console.log('Hidden option triggered');
-    });
+  .action(function () {
+    console.log('Hidden option triggered');
+  });
 
 parser.addOption(null, 'lowercase', 'Only allows lowercase values')
-    .argument('STRING')
-    .validation(function (value) {
-        if (!value.match(/^[a-z]+$/)) {
-            return 'Only lowercase allowed';
-        }
-    });
+  .argument('STRING')
+  .validation(function (value) {
+    if (!value.match(/^[a-z]+$/)) {
+      return 'Only lowercase allowed';
+    }
+  });
 
 parser.addOption([
-    'm',
-    'M',
-    '9'
+  'm',
+  'M',
+  '9'
 ], [
-    'many-ways',
-    'multitude'
+  'many-ways',
+  'multitude'
 ], 'Option can be used many ways');
 
 parser.addOption('o', 'optional', 'Optional argument')
-    .argument('VALUE', false)
-    .action(function (value) {
-        if (value !== null) {
-            console.log('Optional: ' + value);
-        } else {
-            console.log('Optional parameter, no value');
-        }
-    });
+  .argument('VALUE', false)
+  .action(function (value) {
+    if (value !== null) {
+      console.log('Optional: ' + value);
+    } else {
+      console.log('Optional parameter, no value');
+    }
+  });
 
 parser.addOption('r', 'required', 'Required argument')
-    .argument('DATA')
-    .action(function (value) {
-        console.log('Required: ' + value);
-    });
+  .argument('DATA')
+  .action(function (value) {
+    console.log('Required: ' + value);
+  });
 
 parser.addOption('s', null, 'This option should just barely wrap-around-to-the-next-line-but-it-should-chop-this-super-long-word up.');
 
 parser.addOption([
-    'w',
-    'W'
+  'w',
+  'W'
 ], 'wrapping-of-long-description', 'This is a very long description of an option.  It ensures that the text will wrap around and around.  By forcing it to be extremely long we can confirm that implementations perform the proper wrapping and line breaks in the right locations.');
 
 try {
-    unparsed = parser.parse();
-    displayObject({
-        getopt: parser.getopt(),
-        unparsed: unparsed
-    });
+  unparsed = parser.parse();
+  displayObject({
+    getopt: parser.getopt(),
+    unparsed: unparsed
+  });
 } catch (ex) {
-    console.log(ex.message);
+  console.log(ex.message);
 }
 

--- a/lib/option-parameter.js
+++ b/lib/option-parameter.js
@@ -12,41 +12,41 @@
  * @param {string} [message] Short help message
  */
 function OptionParameter(shortOptions, longOptions, message) {
-    if (!(this instanceof OptionParameter)) {
-        return new OptionParameter(shortOptions, longOptions, message);
+  if (!(this instanceof OptionParameter)) {
+    return new OptionParameter(shortOptions, longOptions, message);
+  }
+
+  this.actionClosure = null;
+  this.argumentName = null;
+  this.argumentRequired = 'none';
+  this.getoptFormat = {};
+  this.optionHelp = null;
+  this.optionLong = [];
+  this.optionShort = [];
+  this.validationClosure = null;
+  this.valuesParsed = [];
+
+  if (shortOptions) {
+    if (Array.isArray(shortOptions)) {
+      this.optionShort = shortOptions;
+    } else {
+      this.optionShort = [
+        shortOptions
+      ];
     }
+  }
 
-	this.actionClosure = null;
-	this.argumentName = null;
-	this.argumentRequired = 'none';
-	this.getoptFormat = {};
-	this.optionHelp = null;
-	this.optionLong = [];
-	this.optionShort = [];
-	this.validationClosure = null;
-	this.valuesParsed = [];
+  if (longOptions) {
+    if (Array.isArray(longOptions)) {
+      this.optionLong = longOptions;
+    } else {
+      this.optionLong = [ longOptions ];
+    }
+  }
 
-	if (shortOptions) {
-		if (Array.isArray(shortOptions)) {
-			this.optionShort = shortOptions;
-		} else {
-			this.optionShort = [ 
-                shortOptions
-            ];
-		}
-	}
-
-	if (longOptions) {
-		if (Array.isArray(longOptions)) {
-			this.optionLong = longOptions;
-		} else {
-			this.optionLong = [ longOptions ];
-		}
-	}
-
-	if (message) {
-		this.optionHelp = message;
-	}
+  if (message) {
+    this.optionHelp = message;
+  }
 }
 
 
@@ -57,10 +57,10 @@ function OptionParameter(shortOptions, longOptions, message) {
  * @return {this}
  */
 OptionParameter.prototype.action = function (runThis) {
-	this.validateCallback(runThis);
-	this.actionClosure = runThis;
+  this.validateCallback(runThis);
+  this.actionClosure = runThis;
 
-	return this;
+  return this;
 };
 
 
@@ -72,15 +72,15 @@ OptionParameter.prototype.action = function (runThis) {
  * @return {this}
  */
 OptionParameter.prototype.argument = function (name, required) {
-	this.argumentName = name;
+  this.argumentName = name;
 
-	if (required === undefined || required) {
-		this.argumentRequired = 'required';
-	} else {
-		this.argumentRequired = 'optional';
-	}
+  if (required === undefined || required) {
+    this.argumentRequired = 'required';
+  } else {
+    this.argumentRequired = 'optional';
+  }
 
-	return this;
+  return this;
 };
 
 
@@ -90,7 +90,7 @@ OptionParameter.prototype.argument = function (name, required) {
  * @return {number}
  */
 OptionParameter.prototype.count = function () {
-	return this.valuesParsed.length;
+  return this.valuesParsed.length;
 };
 
 
@@ -103,41 +103,41 @@ OptionParameter.prototype.count = function () {
  * @param {string} [value]
  * @return {this}
  */
-OptionParameter.prototype.handleArgument = function (option, value) {
-    var getoptValue, result;
+OptionParameter.prototype.handleArgument = async function (option, value) {
+  var getoptValue, result;
 
-	if (value !== null && this.validationClosure) {
-		result = this.validationClosure(value);
+  if (value !== null && this.validationClosure) {
+    result = this.validationClosure(value);
 
-		if (result) {
-			var exception = new Error(result);
-			exception.argument = this;
-			throw exception;
-		}
-	}
+    if (result) {
+      var exception = new Error(result);
+      exception.argument = this;
+      throw exception;
+    }
+  }
 
-	if (this.actionClosure) {
-		this.actionClosure(value);
-	}
+  if (this.actionClosure) {
+    await this.actionClosure(value);
+  }
 
-	this.valuesParsed.push(value);
-	getoptValue = false;
+  this.valuesParsed.push(value);
+  getoptValue = false;
 
-	if (this.argumentRequired !== 'none' && value !== null) {
-		getoptValue = value;
-	}
+  if (this.argumentRequired !== 'none' && value !== null) {
+    getoptValue = value;
+  }
 
-	if (this.getoptFormat[option] === undefined) {
-		this.getoptFormat[option] = getoptValue;
-	} else {
-		if (! Array.isArray(this.getoptFormat[option])) {
-			this.getoptFormat[option] = [ this.getoptFormat[option] ];
-		}
+  if (this.getoptFormat[option] === undefined) {
+    this.getoptFormat[option] = getoptValue;
+  } else {
+    if (! Array.isArray(this.getoptFormat[option])) {
+      this.getoptFormat[option] = [ this.getoptFormat[option] ];
+    }
 
-		this.getoptFormat[option].push(getoptValue);
-	}
+    this.getoptFormat[option].push(getoptValue);
+  }
 
-	return this;
+  return this;
 };
 
 
@@ -147,7 +147,7 @@ OptionParameter.prototype.handleArgument = function (option, value) {
  * @return {Array}
  */
 OptionParameter.prototype.getopt = function () {
-	return this.getoptFormat;
+  return this.getoptFormat;
 };
 
 
@@ -157,11 +157,11 @@ OptionParameter.prototype.getopt = function () {
  * @return {number}
  */
 OptionParameter.prototype.getWidth = function () {
-	if (process.stdout.getWindowSize) {
-		return + (process.stdout.getWindowSize()[0]);
-	}
+  if (process.stdout.getWindowSize) {
+    return + (process.stdout.getWindowSize()[0]);
+  }
 
-	return 80;
+  return 80;
 };
 
 
@@ -174,50 +174,50 @@ OptionParameter.prototype.getWidth = function () {
  * @return {string}
  */
 OptionParameter.prototype.help = function (pad, gutter, width) {
-    var buffer, help, options;
+  var buffer, help, options;
 
-    function doDefault(input, defaultValue) {
-		if (input === undefined || +input < 0) {
-			return defaultValue;
-		}
+  function doDefault(input, defaultValue) {
+    if (input === undefined || +input < 0) {
+      return defaultValue;
+    }
 
-		return input;
-	}
+    return input;
+  }
 
-	pad = doDefault(pad, 16);
-	gutter = doDefault(gutter, 2);
-	width = doDefault(width, this.getWidth() - gutter);
-	options = [];
-	buffer = '';
+  pad = doDefault(pad, 16);
+  gutter = doDefault(gutter, 2);
+  width = doDefault(width, this.getWidth() - gutter);
+  options = [];
+  buffer = '';
 
-	if (this.optionHelp === null) {
-		return '';
-	}
+  if (this.optionHelp === null) {
+    return '';
+  }
 
-	this.optionShort.forEach(function (item) {
-		options.push('-' + item);
-	});
-	this.optionLong.forEach(function (item) {
-		options.push('--' + item);
-	});
+  this.optionShort.forEach(function (item) {
+    options.push('-' + item);
+  });
+  this.optionLong.forEach(function (item) {
+    options.push('--' + item);
+  });
 
-	buffer = options.join(', ');
+  buffer = options.join(', ');
 
-	if (this.argumentRequired === 'required') {
-		buffer += ' ' + this.argumentName;
-	} else if (this.argumentRequired === 'optional') {
-		buffer += '[=' + this.argumentName + ']';
-	}
+  if (this.argumentRequired === 'required') {
+    buffer += ' ' + this.argumentName;
+  } else if (this.argumentRequired === 'optional') {
+    buffer += '[=' + this.argumentName + ']';
+  }
 
-	help = this.wrap(this.padding(pad) + this.optionHelp, pad, width);
+  help = this.wrap(this.padding(pad) + this.optionHelp, pad, width);
 
-	if (buffer.length > pad - gutter) {
-		help = this.wrap(buffer, 0, width) + help;
-	} else {
-		help = buffer + help.substr(buffer.length);
-	}
+  if (buffer.length > pad - gutter) {
+    help = this.wrap(buffer, 0, width) + help;
+  } else {
+    help = buffer + help.substr(buffer.length);
+  }
 
-	return help;
+  return help;
 };
 
 
@@ -228,16 +228,16 @@ OptionParameter.prototype.help = function (pad, gutter, width) {
  * @return {Object}
  */
 OptionParameter.prototype.matchAutocomplete = function (arg) {
-	var hits;
-    
-    hits = {};
-	this.optionLong.forEach(function (o) {
-		if (o.substr(0, arg.length) === arg) {
-			hits[o] = this;
-		}
-	});
+  var hits;
 
-	return hits;
+  hits = {};
+  this.optionLong.forEach(function (o) {
+    if (o.substr(0, arg.length) === arg) {
+      hits[o] = this;
+    }
+  });
+
+  return hits;
 };
 
 
@@ -248,9 +248,9 @@ OptionParameter.prototype.matchAutocomplete = function (arg) {
  * @return {boolean}
  */
 OptionParameter.prototype.matchLongArgument = function (arg) {
-	return this.optionLong.some(function (item) {
-		return item === arg;
-	});
+  return this.optionLong.some(function (item) {
+    return item === arg;
+  });
 };
 
 
@@ -261,9 +261,9 @@ OptionParameter.prototype.matchLongArgument = function (arg) {
  * @return {boolean}
  */
 OptionParameter.prototype.matchShortArgument = function (arg) {
-	return this.optionShort.some(function (item) {
-		return item === arg;
-	});
+  return this.optionShort.some(function (item) {
+    return item === arg;
+  });
 };
 
 
@@ -273,9 +273,9 @@ OptionParameter.prototype.matchShortArgument = function (arg) {
  * @return {boolean}
  */
 OptionParameter.prototype.matchWildcard = function () {
-	return this.optionShort.some(function (item) {
-		return item === '*' || item === '-';
-	});
+  return this.optionShort.some(function (item) {
+    return item === '*' || item === '-';
+  });
 };
 
 
@@ -286,12 +286,12 @@ OptionParameter.prototype.matchWildcard = function () {
  * @return {string}
  */
 OptionParameter.prototype.padding = function (length) {
-    var a;
+  var a;
 
-    a = [];
-    a.length = length + 1;
-    
-    return a.join(' ');
+  a = [];
+  a.length = length + 1;
+
+  return a.join(' ');
 };
 
 
@@ -301,7 +301,7 @@ OptionParameter.prototype.padding = function (length) {
  * @return {boolean}
  */
 OptionParameter.prototype.usesArgument = function () {
-	return this.argumentRequired;
+  return this.argumentRequired;
 };
 
 
@@ -312,11 +312,11 @@ OptionParameter.prototype.usesArgument = function () {
  * @return {boolean}
  */
 OptionParameter.prototype.validateCallback = function (runThis) {
-	if (typeof runThis === 'function') {
-		return;
-	}
+  if (typeof runThis === 'function') {
+    return;
+  }
 
-	throw new Error('Invalid closure specified');
+  throw new Error('Invalid closure specified');
 };
 
 
@@ -327,10 +327,10 @@ OptionParameter.prototype.validateCallback = function (runThis) {
  * @return {this}
  */
 OptionParameter.prototype.validation = function (runThis) {
-	this.validateCallback(runThis);
-	this.validationClosure = runThis;
+  this.validateCallback(runThis);
+  this.validationClosure = runThis;
 
-	return this;
+  return this;
 };
 
 
@@ -340,15 +340,15 @@ OptionParameter.prototype.validation = function (runThis) {
  * @return {string}
  */
 OptionParameter.prototype.value = function () {
-	var ret;
-    
-    ret = this.values();
+  var ret;
 
-	if (Array.isArray(ret)) {
-		ret = ret.pop();
-	}
+  ret = this.values();
 
-	return ret;
+  if (Array.isArray(ret)) {
+    ret = ret.pop();
+  }
+
+  return ret;
 };
 
 
@@ -358,11 +358,11 @@ OptionParameter.prototype.value = function () {
  * @return {Array.<string>}
  */
 OptionParameter.prototype.values = function () {
-	if (this.argumentName === null) {
-		return this.count();
-	}
+  if (this.argumentName === null) {
+    return this.count();
+  }
 
-	return this.valuesParsed;
+  return this.valuesParsed;
 };
 
 
@@ -375,36 +375,36 @@ OptionParameter.prototype.values = function () {
  * @return {string}
  */
 OptionParameter.prototype.wrap = function (str, pad, width) {
-    var line, lines, newlineMatch, spacePos, spaces;
+  var line, lines, newlineMatch, spacePos, spaces;
 
-    lines = [];
-	str = str.replace(/[ \t\r\n]*$/, '');
-	spaces = this.padding(pad);
+  lines = [];
+  str = str.replace(/[ \t\r\n]*$/, '');
+  spaces = this.padding(pad);
 
-	while (str.length) {
-		newlineMatch = str.match(/\r?\n|\r/);
+  while (str.length) {
+    newlineMatch = str.match(/\r?\n|\r/);
 
-		if (newlineMatch && newlineMatch.index <= width) {
-			lines.push(str.substr(0, newlineMatch.index - 1));
-			str = str.substr(newlineMatch.index + newlineMatch[0].length);
-		} else {
-			line = str.substr(0, width);
-			spacePos = line.lastIndexOf(' ');
+    if (newlineMatch && newlineMatch.index <= width) {
+      lines.push(str.substr(0, newlineMatch.index - 1));
+      str = str.substr(newlineMatch.index + newlineMatch[0].length);
+    } else {
+      line = str.substr(0, width);
+      spacePos = line.lastIndexOf(' ');
 
-			if (spacePos > width * 0.8) {
-				line = line.substr(0, spacePos + 1);
-			}
+      if (spacePos > width * 0.8) {
+        line = line.substr(0, spacePos + 1);
+      }
 
-			str = str.substr(line.length);
-			lines.push(line.replace(/[ \t\r\n]*$/, ''));
-		}
+      str = str.substr(line.length);
+      lines.push(line.replace(/[ \t\r\n]*$/, ''));
+    }
 
-		if (str.length) {
-			str = spaces + str;
-		}
-	}
+    if (str.length) {
+      str = spaces + str;
+    }
+  }
 
-	return lines.join("\n") + "\n";
+  return lines.join("\n") + "\n";
 };
 
 

--- a/lib/option-parameter.js
+++ b/lib/option-parameter.js
@@ -103,7 +103,7 @@ OptionParameter.prototype.count = function () {
  * @param {string} [value]
  * @return {this}
  */
-OptionParameter.prototype.handleArgument = async function (option, value) {
+OptionParameter.prototype.handleArgument = function (option, value, promisesArr) {
   var getoptValue, result;
 
   if (value !== null && this.validationClosure) {
@@ -117,7 +117,12 @@ OptionParameter.prototype.handleArgument = async function (option, value) {
   }
 
   if (this.actionClosure) {
-    await this.actionClosure(value);
+    // If user has defined an async function, push onto an array of functions to wait on before returning to the main process.
+    if (this.actionClosure && this.actionClosure.constructor.name === 'AsyncFunction') {
+      promisesArr.push(this.actionClosure(value));
+    } else {
+      this.actionClosure(value);
+    }
   }
 
   this.valuesParsed.push(value);

--- a/lib/option-parser.js
+++ b/lib/option-parser.js
@@ -227,7 +227,6 @@ OptionParser.prototype.matchShortOption = function (option) {
   return null;
 };
 
-
 /**
  * Parse an array of options.  When no arguments are passed, the arguments
  * are retrieved from the command line.
@@ -239,7 +238,7 @@ OptionParser.prototype.matchShortOption = function (option) {
  * @return {Array.<string>} Unparsed options
  * @throws {Error} Invalid OptionParameter argument type
  */
-OptionParser.prototype.parse = async function (options) {
+OptionParser.prototype.parse = function (options) {
   var arg, current, found, matches, rest, unparsed, value;
 
   if (!Array.isArray(options)) {
@@ -259,6 +258,8 @@ OptionParser.prototype.parse = async function (options) {
   }
 
   unparsed = [];
+
+  let promisesArr = [];
 
   while (options.length) {
     current = options[0];
@@ -294,7 +295,7 @@ OptionParser.prototype.parse = async function (options) {
         case 'none':
           // Must not use '=' syntax
           // Treat it as another parameter if found
-          await found.handleArgument(arg, null);
+          found.handleArgument(arg, null, promisesArr);
 
           if (value !== null) {
             options.unshift('=' + value);
@@ -312,12 +313,12 @@ OptionParser.prototype.parse = async function (options) {
             value = options.shift();
           }
 
-          await found.handleArgument(arg, value);
+          found.handleArgument(arg, value, promisesArr);
           break;
 
         default:  // optional
           // Must use '=' syntax if a value is to be specified
-          await found.handleArgument(arg, value);
+          found.handleArgument(arg, value, promisesArr);
           break;
         }
       }
@@ -338,7 +339,7 @@ OptionParser.prototype.parse = async function (options) {
         switch (found.usesArgument()) {
         case 'none':
           // Must not use '=' syntax
-          await found.handleArgument(arg, null);
+          found.handleArgument(arg, null, promisesArr);
           options.shift();
 
           if (rest.length) {
@@ -364,7 +365,7 @@ OptionParser.prototype.parse = async function (options) {
             rest = options.shift();
           }
 
-          await found.handleArgument(arg, rest);
+          found.handleArgument(arg, rest, promisesArr);
           break;
 
         case 'optional':
@@ -372,9 +373,9 @@ OptionParser.prototype.parse = async function (options) {
           options.shift();
 
           if (rest.charAt(0) === '=') {
-            await found.handleArgument(arg, rest.substr(1));
+            found.handleArgument(arg, rest.substr(1), promisesArr);
           } else {
-            await found.handleArgument(arg, null);
+            found.handleArgument(arg, null, promisesArr);
 
             if (rest.length) {
               options.unshift('-' + rest);
@@ -394,7 +395,11 @@ OptionParser.prototype.parse = async function (options) {
     }
   }
 
-  return unparsed;
+  if (promisesArr.length) {
+    return Promise.all(promisesArr).then(() => unparsed);
+  } else {
+    return unparsed;
+  }
 };
 
 

--- a/lib/option-parser.js
+++ b/lib/option-parser.js
@@ -9,14 +9,14 @@ OptionParameter = require('./option-parameter');
  * Constructor for the parser object.
  */
 function OptionParser() {
-    if (!(this instanceof OptionParser)) {
-        return new OptionParser();
-    }
+  if (!(this instanceof OptionParser)) {
+    return new OptionParser();
+  }
 
-	this.doAutocomplete = false;
-	this.doScanAll = true;
-	this.parameters = [];
-	this.programNameParsed = null;
+  this.doAutocomplete = false;
+  this.doScanAll = true;
+  this.parameters = [];
+  this.programNameParsed = null;
 }
 
 
@@ -30,14 +30,14 @@ function OptionParser() {
  * @return {OptionParameter}
  */
 OptionParser.prototype.addOption = function (shortName, longName, helpMessage, referenceName) {
-	var op = new OptionParameter(shortName, longName, helpMessage);
-	this.parameters.push(op);
+  var op = new OptionParameter(shortName, longName, helpMessage);
+  this.parameters.push(op);
 
-	if (referenceName) {
-		this[referenceName] = op;
-	}
+  if (referenceName) {
+    this[referenceName] = op;
+  }
 
-	return op;
+  return op;
 };
 
 
@@ -50,9 +50,9 @@ OptionParser.prototype.addOption = function (shortName, longName, helpMessage, r
  * @return {this}
  */
 OptionParser.prototype.autocomplete = function (bool) {
-	this.doAutocomplete = !!bool;  // Force bool to be a boolean
+  this.doAutocomplete = !!bool;  // Force bool to be a boolean
 
-	return this;
+  return this;
 };
 
 
@@ -65,11 +65,11 @@ OptionParser.prototype.autocomplete = function (bool) {
  * @throws {Error} if not found
  */
 OptionParser.prototype.get = function (name) {
-	if (! name || ! this[name]) {
-		throw new Error('No parameter named ' + name);
-	}
+  if (! name || ! this[name]) {
+    throw new Error('No parameter named ' + name);
+  }
 
-	return this[name];
+  return this[name];
 };
 
 
@@ -79,18 +79,18 @@ OptionParser.prototype.get = function (name) {
  * @return {Object}
  */
 OptionParser.prototype.getopt = function () {
-	var out = {};
+  var out = {};
 
-	this.parameters.forEach(function (p) {
-        var getopt;
+  this.parameters.forEach(function (p) {
+    var getopt;
 
-		getopt = p.getopt();
-        Object.keys(getopt).forEach(function (key) {
-            out[key] = getopt[key];
-        });
-	});
+    getopt = p.getopt();
+    Object.keys(getopt).forEach(function (key) {
+      out[key] = getopt[key];
+    });
+  });
 
-	return out;
+  return out;
 };
 
 
@@ -105,7 +105,7 @@ OptionParser.prototype.getopt = function () {
  * @return {string}
  */
 OptionParser.prototype.getValue = function (name) {
-	return this.get(name).value();
+  return this.get(name).value();
 };
 
 
@@ -115,13 +115,13 @@ OptionParser.prototype.getValue = function (name) {
  * @return {string}
  */
 OptionParser.prototype.help = function () {
-	var out = '';
+  var out = '';
 
-	this.parameters.forEach(function (p) {
-		out += p.help();
-	});
+  this.parameters.forEach(function (p) {
+    out += p.help();
+  });
 
-	return out;
+  return out;
 };
 
 
@@ -138,19 +138,19 @@ OptionParser.prototype.help = function () {
  * @return {Function}
  */
 OptionParser.prototype.helpAction = function (cmdline) {
-	if (! cmdline) {
-		cmdline = "[options]";
-	}
+  if (! cmdline) {
+    cmdline = "[options]";
+  }
 
-	var myself = this;
-	return function () {
-		console.log("Usage:");
-		console.log("    " + myself.programName() + " " + cmdline);
-		console.log("");
-		console.log("Available Options:");
-		console.log(myself.help().replace(/\n$/, ''));
-		process.exit(0);
-	};
+  var myself = this;
+  return function () {
+    console.log("Usage:");
+    console.log("    " + myself.programName() + " " + cmdline);
+    console.log("");
+    console.log("Available Options:");
+    console.log(myself.help().replace(/\n$/, ''));
+    process.exit(0);
+  };
 };
 
 
@@ -161,43 +161,43 @@ OptionParser.prototype.helpAction = function (cmdline) {
  * @return {OptionParameter}
  */
 OptionParser.prototype.matchLongOption = function (option) {
-    var i, suggestionCount, suggestionObject;
+  var i, suggestionCount, suggestionObject;
 
-    // Match a regular argument
-    for (i = 0; i < this.parameters.length; i += 1) {
-        if (this.parameters[i].matchLongArgument(option)) {
-            return this.parameters[i];
-        }
+  // Match a regular argument
+  for (i = 0; i < this.parameters.length; i += 1) {
+    if (this.parameters[i].matchLongArgument(option)) {
+      return this.parameters[i];
     }
+  }
 
-    // Autocomplete if possible
-    if (this.doAutocomplete) {
-        suggestionCount = 0;
-        suggestionObject = null;
+  // Autocomplete if possible
+  if (this.doAutocomplete) {
+    suggestionCount = 0;
+    suggestionObject = null;
 
-        this.parameters.forEach(function (p) {
-            var hits;
-            
-            hits = p.matchAutocomplete(option);
-            Object.keys(hits).forEach(function (key) {
-                suggestionCount += 1;
-                suggestionObject = hits[key];
-            });
-        });
+    this.parameters.forEach(function (p) {
+      var hits;
 
-        if (suggestionCount === 1) {
-            return suggestionObject;
-        }
+      hits = p.matchAutocomplete(option);
+      Object.keys(hits).forEach(function (key) {
+        suggestionCount += 1;
+        suggestionObject = hits[key];
+      });
+    });
+
+    if (suggestionCount === 1) {
+      return suggestionObject;
     }
+  }
 
-    // Wildcard if possible
-    for (i = 0; i < this.parameters.length; i += 1) {
-        if (this.parameters[i].matchWildcard(option)) {
-            return this.parameters[i];
-        }
+  // Wildcard if possible
+  for (i = 0; i < this.parameters.length; i += 1) {
+    if (this.parameters[i].matchWildcard(option)) {
+      return this.parameters[i];
     }
+  }
 
-    return null;
+  return null;
 };
 
 
@@ -208,23 +208,23 @@ OptionParser.prototype.matchLongOption = function (option) {
  * @return {OptionParameter}
  */
 OptionParser.prototype.matchShortOption = function (option) {
-    var i;
+  var i;
 
-    // Match a regular argument
-    for (i = 0; i < this.parameters.length; i += 1) {
-        if (this.parameters[i].matchShortArgument(option)) {
-            return this.parameters[i];
-        }
+  // Match a regular argument
+  for (i = 0; i < this.parameters.length; i += 1) {
+    if (this.parameters[i].matchShortArgument(option)) {
+      return this.parameters[i];
     }
+  }
 
-    // Wildcard if possible
-    for (i = 0; i < this.parameters.length; i += 1) {
-        if (this.parameters[i].matchWildcard()) {
-            return this.parameters[i];
-        }
+  // Wildcard if possible
+  for (i = 0; i < this.parameters.length; i += 1) {
+    if (this.parameters[i].matchWildcard()) {
+      return this.parameters[i];
     }
+  }
 
-    return null;
+  return null;
 };
 
 
@@ -239,162 +239,162 @@ OptionParser.prototype.matchShortOption = function (option) {
  * @return {Array.<string>} Unparsed options
  * @throws {Error} Invalid OptionParameter argument type
  */
-OptionParser.prototype.parse = function (options) {
-    var arg, current, found, matches, rest, unparsed, value;
+OptionParser.prototype.parse = async function (options) {
+  var arg, current, found, matches, rest, unparsed, value;
 
-	if (!Array.isArray(options)) {
-		options = process.argv.slice(0);
+  if (!Array.isArray(options)) {
+    options = process.argv.slice(0);
 
-        if (!this.programNameParsed) {
-            // First option is "node", second is program name
-            this.programNameParsed = options.shift() + ' ' + options.shift();
-        } else {
-            options.shift();
-            options.shift();
+    if (!this.programNameParsed) {
+      // First option is "node", second is program name
+      this.programNameParsed = options.shift() + ' ' + options.shift();
+    } else {
+      options.shift();
+      options.shift();
+    }
+  }
+
+  if (!Array.isArray(options)) {
+    throw new Error('Unable to parse options - they are not an array');
+  }
+
+  unparsed = [];
+
+  while (options.length) {
+    current = options[0];
+    arg = null;
+    found = null;
+
+    if (current === '--') {
+      // Designator for the end of arguments
+      options.shift();  // Shift off "--"
+
+      return unparsed.concat(options);
+    }
+
+    if (current.substr(0, 2) === '--') {
+      // Long option
+      arg = current.substr(2);
+      value = null;
+      matches = arg.match(/^([^=]+)=(.*)$/);
+
+      if (matches) {
+        arg = matches[1];
+        value = matches[2];
+      }
+
+      found = this.matchLongOption(arg);
+
+      if (! found) {
+        unparsed.push(options.shift());
+      } else {
+        options.shift();
+
+        switch (found.usesArgument()) {
+        case 'none':
+          // Must not use '=' syntax
+          // Treat it as another parameter if found
+          await found.handleArgument(arg, null);
+
+          if (value !== null) {
+            options.unshift('=' + value);
+          }
+
+          break;
+
+        case 'required':
+          // Can use '=' syntax or next argument
+          if (value === null) {
+            if (! options.length) {
+              throw new Error('Value needed for --' + arg);
+            }
+
+            value = options.shift();
+          }
+
+          await found.handleArgument(arg, value);
+          break;
+
+        default:  // optional
+          // Must use '=' syntax if a value is to be specified
+          await found.handleArgument(arg, value);
+          break;
         }
-	}
+      }
+    } else if (current.charAt(0) === '-') {
+      // Short option
+      arg = current.charAt(1);
+      rest = current.substr(2);
+      found = this.matchShortOption(arg);
 
-	if (!Array.isArray(options)) {
-		throw new Error('Unable to parse options - they are not an array');
-	}
+      if (! found) {
+        unparsed.push('-' + arg);
+        options.shift();
 
-	unparsed = [];
+        if (rest.length) {
+          options.unshift('-' + rest);
+        }
+      } else {
+        switch (found.usesArgument()) {
+        case 'none':
+          // Must not use '=' syntax
+          await found.handleArgument(arg, null);
+          options.shift();
 
-	while (options.length) {
-		current = options[0];
-		arg = null;
-		found = null;
+          if (rest.length) {
+            options.unshift('-' + rest);
+          }
 
-		if (current === '--') {
-			// Designator for the end of arguments
-			options.shift();  // Shift off "--"
+          break;
 
-			return unparsed.concat(options);
-		}
+        case 'required':
+          // Can use '=' syntax, the rest of the current arg
+          // or next argument
+          options.shift();
 
-		if (current.substr(0, 2) === '--') {
-			// Long option
-			arg = current.substr(2);
-			value = null;
-			matches = arg.match(/^([^=]+)=(.*)$/);
+          if (rest.length) {
+            if (rest.charAt(0) === '=') {
+              rest = rest.substr(1);
+            }
+          } else {
+            if (! options.length) {
+              throw new Error('Value needed for -' + arg);
+            }
 
-			if (matches) {
-				arg = matches[1];
-				value = matches[2];
-			}
+            rest = options.shift();
+          }
 
-            found = this.matchLongOption(arg);
+          await found.handleArgument(arg, rest);
+          break;
 
-			if (! found) {
-                unparsed.push(options.shift());
-			} else {
-                options.shift();
+        case 'optional':
+          // Must use '=' syntax
+          options.shift();
 
-				switch (found.usesArgument()) {
-					case 'none':
-						// Must not use '=' syntax
-						// Treat it as another parameter if found
-						found.handleArgument(arg, null);
+          if (rest.charAt(0) === '=') {
+            await found.handleArgument(arg, rest.substr(1));
+          } else {
+            await found.handleArgument(arg, null);
 
-						if (value !== null) {
-							options.unshift('=' + value);
-						}
+            if (rest.length) {
+              options.unshift('-' + rest);
+            }
+          }
+          break;
 
-						break;
+        default:
+          throw new Error('Invalid OptionParameter argument type: ' + found.usesArgument());
+        }
+      }
+    } else if (this.doScanAll) {
+      unparsed.push(options.shift());
+    } else {
+      // Stopping at first unknown
+      return unparsed.concat(options);
+    }
+  }
 
-					case 'required':
-						// Can use '=' syntax or next argument
-						if (value === null) {
-							if (! options.length) {
-								throw new Error('Value needed for --' + arg);
-							}
-
-							value = options.shift();
-						}
-
-						found.handleArgument(arg, value);
-						break;
-
-					default:  // optional
-						// Must use '=' syntax if a value is to be specified
-						found.handleArgument(arg, value);
-						break;
-				}
-			}
-		} else if (current.charAt(0) === '-') {
-			// Short option
-			arg = current.charAt(1);
-			rest = current.substr(2);
-            found = this.matchShortOption(arg);
-
-			if (! found) {
-				unparsed.push('-' + arg);
-				options.shift();
-
-				if (rest.length) {
-					options.unshift('-' + rest);
-				}
-			} else {
-				switch (found.usesArgument()) {
-					case 'none':
-						// Must not use '=' syntax
-						found.handleArgument(arg, null);
-						options.shift();
-
-						if (rest.length) {
-							options.unshift('-' + rest);
-						}
-
-						break;
-
-					case 'required':
-						// Can use '=' syntax, the rest of the current arg
-						// or next argument
-						options.shift();
-
-						if (rest.length) {
-							if (rest.charAt(0) === '=') {
-								rest = rest.substr(1);
-							}
-						} else {
-							if (! options.length) {
-								throw new Error('Value needed for -' + arg);
-							}
-
-							rest = options.shift();
-						}
-
-						found.handleArgument(arg, rest);
-						break;
-
-					case 'optional':
-						// Must use '=' syntax
-						options.shift();
-
-						if (rest.charAt(0) === '=') {
-							found.handleArgument(arg, rest.substr(1));
-						} else {
-							found.handleArgument(arg, null);
-
-							if (rest.length) {
-								options.unshift('-' + rest);
-							}
-						}
-						break;
-
-					default:
-						throw new Error('Invalid OptionParameter argument type: ' + found.usesArgument());
-				}
-			}
-		} else if (this.doScanAll) {
-			unparsed.push(options.shift());
-		} else {
-			// Stopping at first unknown
-			return unparsed.concat(options);
-		}
-	}
-
-	return unparsed;
+  return unparsed;
 };
 
 
@@ -404,11 +404,11 @@ OptionParser.prototype.parse = function (options) {
  * @return {string}
  */
 OptionParser.prototype.programName = function (newName) {
-    if (newName !== undefined) {
-        this.programNameParsed = newName;
-    }
+  if (newName !== undefined) {
+    this.programNameParsed = newName;
+  }
 
-	return this.programNameParsed;
+  return this.programNameParsed;
 };
 
 
@@ -419,9 +419,9 @@ OptionParser.prototype.programName = function (newName) {
  * @return {this}
  */
 OptionParser.prototype.scanAll = function (bool) {
-	this.doScanAll = !!bool;  // Force bool to be a boolean
+  this.doScanAll = !!bool;  // Force bool to be a boolean
 
-    return this;
+  return this;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "option-parser",
-	"version": "1.0.2",
+	"version": "2.0.0",
 	"author": "Tyler Akins <fidian@rumkin.com>",
 	"description": "Command-line option parser similar to getopt",
 	"homepage": "https://github.com/tests-always-included/option-parser/",


### PR DESCRIPTION
This update returns a Promise on the .parse() function to enable passing Promise functions to .action(). This allows you to run async functions in the action handlers without the program continuing until the function is complete. Just pass it like

.action(async (optionValue) {
  await someAsyncFunction();
    if (optionValue) {
      doOtherStuff()
    }
});

Then, of course, optionParser.parse() needs to be waited on with an "await optionParser.parse().catch()" or "optionParser.parse().then().catch()"

You can ignore all of the white space changes, I just fixed it so those files  aren't in both tabs and spaces. The only important parts are the async/awaits in OptionParser.prototype.parse and OptionParameter.prototype.handleArgument

This is a non-backwards change so a new version would have to be released. This does allow you to interface with all handling of option parameters in a consistent, modern JS way. 

The use case I had was my project has a parameter that runs some async function. Well, to make this work I cannot set .action() on the OptionParameter for these since it will not wait for the async function to complete before continuing the program. To work around this, after you call the .parse() function, I had to do some checks for optionParser.paramOption.value() and then manage the async code. This brings it so even async functions can be managed in the .action() just like non-async functions.

If you're not interested in this change, that's fine, I'll just use my forked version for my project. If you are, there is still work that needs to be done to update the README and probably the tests need updated.

Let me know what you think! Also worth noting is this project will now require a slightly higher version of Node to run that supports async/await. But that would still be like a 5 year old version of node so I don't think that's much of a concern.